### PR TITLE
Improve GeoTOP code

### DIFF
--- a/docs/examples/15_geotop.ipynb
+++ b/docs/examples/15_geotop.ipynb
@@ -107,7 +107,7 @@
    "id": "ace59ae0",
    "metadata": {},
    "source": [
-    "We plot the lithoclass (soil types) in a cross-section using the method `nlmod.read.geotop.plot_cross_section`."
+    "We plot the lithoclass (soil types) in a cross-section using the method `nlmod.plot.geotop_lithok_in_cross_section`."
    ]
   },
   {
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "f, ax = plt.subplots(figsize=(10, 5))\n",
-    "nlmod.read.geotop.plot_cross_section(line, gt)\n",
+    "nlmod.plot.geotop_lithok_in_cross_section(line, gt)\n",
     "f.tight_layout(pad=0.0)"
    ]
   },
@@ -306,7 +306,7 @@
    "metadata": {},
    "source": [
     "## Aggregate voxels to REGIS-layers\n",
-    "We can use any layer model in `nlmod.read.geotop.aggregate_to_ds()`, also one from REGIS. Let's demonstrate this by downloading REGIS-data from the same model extent."
+    "We can use any layer model in `nlmod.read.geotop.aggregate_to_ds()`, also one from REGIS. Let's demonstrate this by downloading REGIS-data for the same extent."
    ]
   },
   {
@@ -428,7 +428,7 @@
    "id": "27411195",
    "metadata": {},
    "source": [
-    "We can plot the kh- and kv-values again. Using the stochastic data results in smoother values for kh and kv."
+    "We can plot the kh- and kv-values again. Using the stochastic data generally results in smoother values for kh and kv."
    ]
   },
   {

--- a/docs/examples/15_geotop.ipynb
+++ b/docs/examples/15_geotop.ipynb
@@ -1,0 +1,477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c5755f8",
+   "metadata": {},
+   "source": [
+    "# Using information from GeoTOP\n",
+    "Most geohydrological models in the Netherlands use the layer model REGIS as the base for the geohydrological properties of the model. REGIS does not contain information for all layers though, of which the holocene confining layer (HLc) is the most important one. In this notebook we will show how to use the voxel model GeoTOP to generate geohydrolocal properties for this layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e89ac62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.geometry import LineString\n",
+    "import matplotlib.pyplot as plt\n",
+    "import nlmod\n",
+    "import matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0de3f47d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nlmod.util.get_color_logger('INFO');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d102e9d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define an extent and a line from southwest to northeast through this extent\n",
+    "extent = [95000.0, 105000.0, 494000.0, 500000.0]\n",
+    "line = LineString([(extent[0], extent[2]), (extent[1], extent[3])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38282cfc",
+   "metadata": {},
+   "source": [
+    "We define a method called 'plot_kh_kv', which we can call in cells below to plot the horizontal and vertical conductivity in a cross-section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0df7d7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_kh_kv(ds, layer=\"layer\", variables=None, zmin=-50.25, min_label_area=None, cmap=None, norm=None):\n",
+    "    if variables is None:\n",
+    "        variables = [\"kh\", \"kv\"]\n",
+    "    if cmap is None:\n",
+    "        cmap = plt.get_cmap(\"turbo_r\")\n",
+    "    if norm is None:\n",
+    "        boundaries = [0.0001, 0.001, 0.01, 0.1, 1, 5, 10, 20, 50, 100]\n",
+    "        norm = matplotlib.colors.BoundaryNorm(boundaries, cmap.N)\n",
+    "    for var in variables:\n",
+    "        f, ax = plt.subplots(figsize=(10, 5))\n",
+    "        cs = nlmod.dcs.DatasetCrossSection(ds, line, layer=layer, ax=ax, zmin=zmin)\n",
+    "        pc = cs.plot_array(ds[var], norm=norm, cmap=cmap)\n",
+    "        if min_label_area is not None:\n",
+    "            cs.plot_layers(alpha=0.0, min_label_area=min_label_area)\n",
+    "            cs.plot_grid(vertical=False)\n",
+    "        format = matplotlib.ticker.FuncFormatter(lambda y, _: '{:g}'.format(y))\n",
+    "        nlmod.plot.colorbar_inside(pc, bounds=[0.05, 0.05, 0.02, 0.9], format=format)\n",
+    "        nlmod.plot.title_inside(var, ax=ax)\n",
+    "        ax.set_xlabel('afstand langs doorsnede (m)')\n",
+    "        ax.set_ylabel('z (m NAP)')\n",
+    "        f.tight_layout(pad=0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aefeba72",
+   "metadata": {},
+   "source": [
+    "## Download GeoTOP\n",
+    "We download GeoTOP for a certain extent. We get an xarray.Dataset with voxels of 100 * 100 * 0.5 (dx * dy * dz) m, with variables 'strat' and 'lithok'. We also get the probaliblity of the occurence of each lithoclass in variables named 'kans_*' (as `drop_probabilities` is `False`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb437747",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt = nlmod.read.geotop.get_geotop_raw_within_extent(extent, drop_probabilities=False)\n",
+    "gt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ace59ae0",
+   "metadata": {},
+   "source": [
+    "We plot the lithoclass (soil types) in a cross-section using the method `nlmod.read.geotop.plot_cross_section`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b86b6b8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots(figsize=(10, 5))\n",
+    "nlmod.read.geotop.plot_cross_section(line, gt)\n",
+    "f.tight_layout(pad=0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5577c352",
+   "metadata": {},
+   "source": [
+    "## Add hydrological properties (kh and kv)\n",
+    "GeoTOP does not contain information about geohydroloical propties directly. We need to calculate this information, using the lithoclass, and optionally the stratigraphy (layer unit). We get this information from a DataFrame, whch needs to contain the columns 'lithok' and 'kh' (and optionally 'strat' and 'kv')."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9506f77d",
+   "metadata": {},
+   "source": [
+    "### Based on lithok\n",
+    "With `nlmod.read.geotop.get_lithok_props()` we get a default value for each of the 9 lithoclasses (lthok 4 is not used). These values are a rough estimate of the hydrologic conductivity. We recommend changing these values based on local conditions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4429541a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = nlmod.read.geotop.get_lithok_props()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "932b8994",
+   "metadata": {},
+   "source": [
+    "The method `nlmod.read.geotop.add_kh_and_kv` takes this DataFrame, applies it to the GeoTOP voxel-dataset `gt`, and adds the varaiables `kh` and `kv` to `gt`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11c61bec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt = nlmod.read.geotop.add_kh_and_kv(gt, df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f2e2f5c",
+   "metadata": {},
+   "source": [
+    "When we plot kh and kv we see fine sands get a value of 5 m/d (green) and medium fine sands get a value of 10 m/d (light blue). We see the peat (0.001 m/d) and clay (0.01 m/d) layers as zones with lower conductivities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa2b2a04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(gt, layer=\"z\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18450570",
+   "metadata": {},
+   "source": [
+    "### Based on lithok and strat\n",
+    "We can also load one of the other  DataFrames that are built into nlmod, using the method `nlmod.geotop.get_kh_kv_table()`. Using this method, a table for certain location can be loaded. Right now, the only allowed value for `kind` is 'Brabant', which is the default value, and loads the hydrological properties per lithoclass and stratigraphic unit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2624408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = nlmod.read.geotop.get_kh_kv_table()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b8d252b",
+   "metadata": {},
+   "source": [
+    "We use this table to add a kh and kv value for each voxel, in variables named 'kh' and 'kv'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d8ca0fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt = nlmod.read.geotop.add_kh_and_kv(gt, df)\n",
+    "gt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015399df",
+   "metadata": {},
+   "source": [
+    "We can plot these values along the same line we plotted the lithoclass-values in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0665b527",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(gt, layer=\"z\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d93c5189",
+   "metadata": {},
+   "source": [
+    "## Aggregate voxels to GeoTOP-layers\n",
+    "In the previous example we have added geodrological properties to the voxels of GeoTOP and plotted them. The layers of a groundwatermodel generally are thicker than the thickness of the voxels (0.5 m). Therefore we need to aggregate the voxel-data into the layers of the model. We show this process by using the stratigraphy-data of GeoTOP to form a layer model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30b334c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gtl = nlmod.read.geotop.convert_geotop_to_ml_layers(gt)\n",
+    "gtl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a558bad3",
+   "metadata": {},
+   "source": [
+    "We then add geohydrological properties to this layer model using the method `nlmod.read.geotop.aggregate_to_ds`. The method calculates the combined horizontal transmissivity, and the combined vertical resistance of all (parts of) voxels in a layer, and calculates a kh and kv value from this transmissivity and resistance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ffbe6f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gtl = nlmod.read.geotop.aggregate_to_ds(gt, gtl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f328978",
+   "metadata": {},
+   "source": [
+    "We can plot the kh and kv value for each of the layers with the same method we used for the voxel-data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b572bd90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(gtl, min_label_area=1000.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f274bf06",
+   "metadata": {},
+   "source": [
+    "## Aggregate voxels to REGIS-layers\n",
+    "We can use any layer model in `nlmod.read.geotop.aggregate_to_ds()`, also one from REGIS. Let's demonstrate this by downloading REGIS-data from the same model extent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd95c4ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regis = nlmod.read.get_regis(extent)\n",
+    "regis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87d0e5d0",
+   "metadata": {},
+   "source": [
+    "First we plot the original hydrological properties of REGIS. We see that kh is defined for the aquifers (top plot) and kv is defined for the aquitards (bottom plot). Neither kh or kv is defined for the top layer HLc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fede3a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(regis, min_label_area=1000., zmin=-100.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72fe6c86",
+   "metadata": {},
+   "source": [
+    "We will add varibales `kh_gt` and `kv_gt` with the kh- and kv-values calculated from GeoTOP. Layers that do not contain any voxel will get a NaN-value for kh and kv.\n",
+    "First we make sure the geotop-data and regis-data are defined at the same coordinates by using neareast interpolation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9352536",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gtr = gt.interp({\"x\": regis.x, \"y\": regis.y}, method='nearest')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a32ee6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make sure there are no NaNs in top and botm of layers\n",
+    "regis = nlmod.layers.fill_top_and_bottom(regis)\n",
+    "regis = nlmod.read.geotop.aggregate_to_ds(gtr, regis, kh='kh_gt', kv='kv_gt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a618866",
+   "metadata": {},
+   "source": [
+    "When we plot the kh and kv value, we see all layers above -50 m NAP now contain values, calculated from the GeoTOP-data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3a3f1eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(regis, min_label_area=1000., zmin=-100., variables=['kh_gt', 'kv_gt'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44a537a1",
+   "metadata": {},
+   "source": [
+    "We can plot kh of one of the layers on a map, for both REGIS and GeoTOP. We generally see that conductivities in GeoTOP are a bit lower."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "681c0d58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer='KRz3'\n",
+    "var = 'kh'\n",
+    "norm = matplotlib.colors.Normalize(0.0, 40.0)\n",
+    "\n",
+    "f, axes = nlmod.plot.get_map(extent, ncols=2)\n",
+    "pc = nlmod.plot.data_array(regis[var].loc[layer], ax=axes[0], norm=norm)\n",
+    "nlmod.plot.colorbar_inside(pc, bounds=[0.02, 0.05, 0.02, 0.9], ax=axes[0])\n",
+    "nlmod.plot.title_inside('REGIS', ax=axes[0])\n",
+    "pc = nlmod.plot.data_array(regis[f'{var}_gt'].loc[layer], ax=axes[1], norm=norm)\n",
+    "nlmod.plot.title_inside('GeoTOP', ax=axes[1])\n",
+    "nlmod.plot.colorbar_inside(pc, bounds=[0.02, 0.05, 0.02, 0.9], ax=axes[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be7292b5",
+   "metadata": {},
+   "source": [
+    "## Using stochastic data from GeoTOP\n",
+    "In the previous section we used the most likely values from the lithoclass-data of GeoTOP. GeoTOP is constructed by generating 100 realisations of this data. Using these realisations a probablity is determined for the occurence in each pixel for each of the lithoclassses. We can also use these probabilities to determine the kh and kv-value of each voxel. We do this by settting the `stochastic` parameter in `nlmod.read.geotop.add_kh_and_kv` to True. The kh and kv values are now calculated by a weighted average of the lithoclass-data in each voxel, where the weights are determined by the probablilities. By default a arithmetic weighted mean is used for kh and a harmonic weighted mean for kv, but these methods can be chosen by the user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1de603a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gt = nlmod.read.geotop.add_kh_and_kv(gt, df, stochastic=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27411195",
+   "metadata": {},
+   "source": [
+    "We can plot the kh- and kv-values again. Using the stochastic data results in smoother values for kh and kv."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41bc6161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_kh_kv(gt, layer=\"z\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/15_geotop.ipynb
+++ b/docs/examples/15_geotop.ipynb
@@ -343,18 +343,7 @@
    "id": "72fe6c86",
    "metadata": {},
    "source": [
-    "We will add varibales `kh_gt` and `kv_gt` with the kh- and kv-values calculated from GeoTOP. Layers that do not contain any voxel will get a NaN-value for kh and kv.\n",
-    "First we make sure the geotop-data and regis-data are defined at the same coordinates by using neareast interpolation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e9352536",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gtr = gt.interp({\"x\": regis.x, \"y\": regis.y}, method='nearest')"
+    "We will add varibales `kh_gt` and `kv_gt` that contain the kh- and kv-values calculated from GeoTOP. Layers that do not contain any voxel will get a NaN-value for kh and kv."
    ]
   },
   {
@@ -366,7 +355,7 @@
    "source": [
     "# make sure there are no NaNs in top and botm of layers\n",
     "regis = nlmod.layers.fill_top_and_bottom(regis)\n",
-    "regis = nlmod.read.geotop.aggregate_to_ds(gtr, regis, kh='kh_gt', kv='kv_gt')"
+    "regis = nlmod.read.geotop.aggregate_to_ds(gt, regis, kh='kh_gt', kv='kv_gt')"
    ]
   },
   {

--- a/nlmod/data/geotop/geo_eenheden.csv
+++ b/nlmod/data/geotop/geo_eenheden.csv
@@ -1,4 +1,4 @@
-Nummer (voxelmode),Code (lagenmodel en boringen),Naam
+strat,code,name
 1000,AAOP,Antropogene afzettingen
 1005,AAES,"Antropogene afzettingen, esdekken"
 1010,NIGR,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen"

--- a/nlmod/data/geotop/geo_eenheden.csv
+++ b/nlmod/data/geotop/geo_eenheden.csv
@@ -1,5 +1,6 @@
 Nummer (voxelmode),Code (lagenmodel en boringen),Naam
 1000,AAOP,Antropogene afzettingen
+1005,AAES,"Antropogene afzettingen, esdekken"
 1010,NIGR,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen"
 1020,NASC,"Formatie van Naaldwijk, Laagpakket van Schoorl"
 1030,ONAWA,"Formatie van Naaldwijk, Laagpakket van
@@ -22,7 +23,9 @@ Wormer en Zandvoort (gecombineerde eenheid in modelgebied Zeeland)"
 2030,KK,Kreekrak Formatie
 3000,BXKO,"Formatie van Boxtel, Laagpakket van Kootwijk"
 3010,BXSI,"Formatie van Boxtel, Laagpakket van Singraven"
+3011,BXSI,"Formatie van Boxtel Laagpakket van Singraven (bovenste deel)"
 3020,BXWI,"Formatie van Boxtel, Laagpakket van Wierden"
+3025,BXWIKO,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk"
 3030,BXWISIKO,"Formatie van Boxtel, Laagpakketten van Wierden, Singraven en Kootwijk"
 3040,BXDE,"Formatie van Boxtel, Laagpakket van Delwijnen"
 3050,BXSC,"Formatie van Boxtel, Laagpakket van Schimmert"

--- a/nlmod/data/geotop/hydraulische_parameterisering_geotop_noord-brabant_en_noord-_en_midden-limburg.csv
+++ b/nlmod/data/geotop/hydraulische_parameterisering_geotop_noord-brabant_en_noord-_en_midden-limburg.csv
@@ -1,0 +1,398 @@
+Eenheid,strat,Beschrijving,lithok,Lithoklasse,kh,kv
+AAES,1005,"Antropogene afzettingen, esdekken",1,Organisch materiaal (veen) ,0.049,0.049
+AAES,1005,"Antropogene afzettingen, esdekken",2,Klei ,0.004,0.004
+AAES,1005,"Antropogene afzettingen, esdekken",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+AAES,1005,"Antropogene afzettingen, esdekken",5,Fijn zand ,1.38654620920253,0.566129825095818
+AAES,1005,"Antropogene afzettingen, esdekken",6,Midden zand ,1.68810513168277,0.486890770458667
+AAES,1005,"Antropogene afzettingen, esdekken",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+AAES,1005,"Antropogene afzettingen, esdekken",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+AAOP,1000,"Antropogene afzettingen, opgebrachte grond",0,Antropogeen ,1.0,1.0
+BE,4080,Formatie van Beegden,1,Organisch materiaal (veen) ,0.049,0.049
+BE,4080,Formatie van Beegden,2,Klei ,3.38835745416981,0.00826310865323914
+BE,4080,Formatie van Beegden,3,"Kleiig zand, zandige klei en leem ",3.38835745416981,0.00826310865323914
+BE,4080,Formatie van Beegden,5,Fijn zand ,4.199231868,2.10646786974217
+BE,4080,Formatie van Beegden,6,Midden zand ,4.37434787002799,2.10646786974217
+BE,4080,Formatie van Beegden,7,"Grof zand, grind en schelpen ",16.0173957746441,12.1433954600592
+BE,4080,Formatie van Beegden,8,Grind (indien apart gemodelleerd) ,170.0,170.0
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",1,Organisch materiaal (veen) ,0.049,0.049
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",2,Klei ,0.119350064610401,0.00941837448093238
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",3,"Kleiig zand, zandige klei en leem ",0.119350064610401,0.02
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",5,Fijn zand ,4.199231868,3.871552231
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",6,Midden zand ,7.5521518,7.589237854
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",7,"Grof zand, grind en schelpen ",58.0,58.0
+BEOM,4055,"Formatie van Beegden, Laagpakket van Oost-Maarland",8,Grind (indien apart gemodelleerd) ,170.0,170.0
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",1,Organisch materiaal (veen) ,0.049,0.049
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",2,Klei ,0.119350064610401,0.00941837448093238
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",3,"Kleiig zand, zandige klei en leem ",0.119350064610401,0.02
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",5,Fijn zand ,4.199231868,3.871552231
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",6,Midden zand ,7.5521518,7.589237854
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",7,"Grof zand, grind en schelpen ",58.0,58.0
+BEOMga,6005,"Formatie van Beegden, Laagpakket van Oost-Maarland (geulafzettingen generatie A)",8,Grind (indien apart gemodelleerd) ,170.0,170.0
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",1,Organisch materiaal (veen) ,0.049,0.049
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",2,Klei ,0.000463193797377168,1.92702773432065e-05
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",3,"Kleiig zand, zandige klei en leem ",0.02,0.02
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",5,Fijn zand ,4.503260185,4.019383198
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",6,Midden zand ,9.003718377,7.589237854
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",7,"Grof zand, grind en schelpen ",29.5,29.5
+BERO,4070,"Formatie van Beegden, Laag van Rosmalen",8,Grind (indien apart gemodelleerd) ,170.0,170.0
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",1,Organisch materiaal (veen) ,0.049,0.049
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",2,Klei ,0.0100820629495191,3.16125122432287e-05
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",3,"Kleiig zand, zandige klei en leem ",0.02,0.02
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",5,Fijn zand ,2.188543727,1.726913572
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",6,Midden zand ,9.224219039,3.713409936
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",7,"Grof zand, grind en schelpen ",58.8,58.8
+BEWY,4060,"Formatie van Beegden, Laag van Wijchen",8,Grind (indien apart gemodelleerd) ,170.0,170.0
+BRVI,5180,Formatie van Breda,1,Organisch materiaal (veen) ,1.676e-05,1.676e-05
+BRVI,5180,Formatie van Breda,2,Klei ,0.855857283012776,0.146044501214838
+BRVI,5180,Formatie van Breda,3,"Kleiig zand, zandige klei en leem ",0.855857283012776,0.146044501214838
+BRVI,5180,Formatie van Breda,5,Fijn zand ,0.580559674102038,0.436189740888889
+BRVI,5180,Formatie van Breda,6,Midden zand ,2.00148995705411,1.56597672871734
+BRVI,5180,Formatie van Breda,7,"Grof zand, grind en schelpen ",24.2,24.2
+BRVI,5180,Formatie van Breda,8,Grind (indien apart gemodelleerd) ,24.2,24.2
+BX,3100,Formatie van Boxtel,1,Organisch materiaal (veen) ,0.0356754824785762,0.00426573894089705
+BX,3100,Formatie van Boxtel,2,Klei ,0.714505711729118,0.00149845913963061
+BX,3100,Formatie van Boxtel,3,"Kleiig zand, zandige klei en leem ",0.714505711729118,0.00149845913963061
+BX,3100,Formatie van Boxtel,5,Fijn zand ,0.786227576309262,0.174537220436516
+BX,3100,Formatie van Boxtel,6,Midden zand ,3.18873760998214,1.42612283412274
+BX,3100,Formatie van Boxtel,7,"Grof zand, grind en schelpen ",10.472831171925,7.5619515980503
+BX,3100,Formatie van Boxtel,8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",1,Organisch materiaal (veen) ,0.049,0.049
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",2,Klei ,0.000689126865370383,0.000259858716460823
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",5,Fijn zand ,0.213536660595521,0.0579000277706742
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",6,Midden zand ,0.213536660595521,0.0579000277706742
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXBS,3090,"Formatie van Boxtel, Laagpakket van Best",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",1,Organisch materiaal (veen) ,0.049,0.049
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",2,Klei ,0.004,0.004
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",5,Fijn zand ,2.561153112,1.829919461
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",6,Midden zand ,4.34294368871927,2.79514163741299
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",7,"Grof zand, grind en schelpen ",18.9297498078921,18.4419595051675
+BXDE,3040,"Formatie van Boxtel, Laagpakket van Delwijnen",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",1,Organisch materiaal (veen) ,0.049,0.049
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",2,Klei ,0.004,0.004
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",5,Fijn zand ,2.561153112,1.829919461
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",6,Midden zand ,4.34294368871927,2.79514163741299
+BXDEKO,3045,"Formatie van Boxtel, laagpakketten van Delwijnen en Kootwijk",7,"Grof zand, grind en schelpen ",18.9297498078921,18.4419595051675
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",1,Organisch materiaal (veen) ,0.049,0.049
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",2,Klei ,0.004,0.004
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",5,Fijn zand ,2.561153112,1.829919461
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",6,Midden zand ,8.2442727794426,7.22089296355223
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXKO,3000,"Formatie van Boxtel, Laagpakket van Kootwijk",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",1,Organisch materiaal (veen) ,0.049,0.049
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",2,Klei ,0.00628291186300714,0.000175303532389399
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",3,"Kleiig zand, zandige klei en leem ",0.00628291186300714,0.004
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",5,Fijn zand ,2.561153112,1.829919461
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",6,Midden zand ,4.863951424,4.600268917
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXLM,3060,"Formatie van Boxtel, Laagpakket van Liempde",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",1,Organisch materiaal (veen) ,0.049,0.049
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",2,Klei ,0.016,0.016
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",3,"Kleiig zand, zandige klei en leem ",0.016,0.016
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",5,Fijn zand ,2.561153112,1.829919461
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",6,Midden zand ,4.863951424,4.600268917
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXSC,3050,"Formatie van Boxtel, Laagpakket van Schimmert",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),1,Organisch materiaal (veen) ,0.049,0.049
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),2,Klei ,2.71972226039398,0.0866446039229639
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),3,"Kleiig zand, zandige klei en leem ",2.71972226039398,0.0866446039229639
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),5,Fijn zand ,2.561153112,0.801933888727038
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),6,Midden zand ,4.70316168428883,0.801933888727038
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXSI,3011,Formatie van Boxtel Laagpakket van Singraven (bovenste deel),8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",1,Organisch materiaal (veen) ,0.049,0.049
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",2,Klei ,0.004,0.004
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",5,Fijn zand ,1.38654620920253,0.566129825095818
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",6,Midden zand ,1.68810513168277,0.486890770458667
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXWI,3020,"Formatie van Boxtel, Laagpakket van Wierden",8,Grind (indien apart gemodelleerd) ,13.11456074,13.11456074
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",1,Organisch materiaal (veen) ,0.049,0.049
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",2,Klei ,0.004,0.004
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",5,Fijn zand ,1.38654620920253,0.566129825095818
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",6,Midden zand ,1.68810513168277,0.486890770458667
+BXWIKO,3025,"Formatie van Boxtel, laagpakketten van Wierden en Kootwijk",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",1,Organisch materiaal (veen) ,0.049,0.049
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",2,Klei ,0.004,0.004
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",5,Fijn zand ,1.38654620920253,0.566129825095818
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",6,Midden zand ,1.68810513168277,0.486890770458667
+BXWISIKO,3030,"Formatie van Boxtel, laagpakketten van Wierden, Singraven en Kootwijk",7,"Grof zand, grind en schelpen ",12.028216,10.22360777
+DR,5000,Formatie van Drente,1,Organisch materiaal (veen) ,0.049,0.049
+DR,5000,Formatie van Drente,2,Klei ,0.0046,0.0046
+DR,5000,Formatie van Drente,3,"Kleiig zand, zandige klei en leem ",0.04,0.04
+DR,5000,Formatie van Drente,5,Fijn zand ,1.948874049,1.914822689
+DR,5000,Formatie van Drente,6,Midden zand ,10.32039905,7.157790695
+DR,5000,Formatie van Drente,7,"Grof zand, grind en schelpen ",34.1,34.1
+DR,5000,Formatie van Drente,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",1,Organisch materiaal (veen) ,0.049,0.049
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",2,Klei ,0.0481353087218994,0.000444466463879532
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",3,"Kleiig zand, zandige klei en leem ",0.0481353087218994,0.000444466463879532
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",5,Fijn zand ,0.0464733625776641,0.00134877871741091
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",6,Midden zand ,0.0464733625776641,0.00134877871741091
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",7,"Grof zand, grind en schelpen ",34.1,34.1
+DRGI,5010,"Formatie van Drente, Laagpakket van Gieten",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),2,Klei ,0.252419401614129,9.4837952411877e-05
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),5,Fijn zand ,3.052346743,1.59382820196623
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),6,Midden zand ,4.70110165253667,1.59382820196623
+EC1,1070,Formatie van Echteld (gedeelte boven NIHO),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+EC2,2010,Formatie van Echteld,1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+EC2,2010,Formatie van Echteld,2,Klei ,0.252419401614129,9.4837952411877e-05
+EC2,2010,Formatie van Echteld,3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+EC2,2010,Formatie van Echteld,5,Fijn zand ,3.052346743,1.59382820196623
+EC2,2010,Formatie van Echteld,6,Midden zand ,4.70110165253667,1.59382820196623
+EC2,2010,Formatie van Echteld,7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+EC2,2010,Formatie van Echteld,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),2,Klei ,0.252419401614129,9.4837952411877e-05
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),5,Fijn zand ,3.052346743,1.59382820196623
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),6,Midden zand ,4.70110165253667,1.59382820196623
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+ECga,6000,Formatie van Echteld (geulafzettingen generatie A),8,Grind (indien apart gemodelleerd) ,85.1,85.1
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),2,Klei ,0.252419401614129,9.4837952411877e-05
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),5,Fijn zand ,3.052346743,1.59382820196623
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),6,Midden zand ,4.70110165253667,1.59382820196623
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+ECgb,6100,Formatie van Echteld (geulafzettingen generatie B),8,Grind (indien apart gemodelleerd) ,85.1,85.1
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),2,Klei ,0.252419401614129,9.4837952411877e-05
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),5,Fijn zand ,3.052346743,1.59382820196623
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),6,Midden zand ,4.70110165253667,1.59382820196623
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+ECgc,6200,Formatie van Echteld (geulafzettingen generatie C),8,Grind (indien apart gemodelleerd) ,85.1,85.1
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),2,Klei ,0.252419401614129,9.4837952411877e-05
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),5,Fijn zand ,3.052346743,1.59382820196623
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),6,Midden zand ,4.70110165253667,1.59382820196623
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+ECgd,6300,Formatie van Echteld (geulafzettingen generatie D),8,Grind (indien apart gemodelleerd) ,85.1,85.1
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),1,Organisch materiaal (veen) ,0.00553006545538125,6.64450166049668e-05
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),2,Klei ,0.252419401614129,9.4837952411877e-05
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),3,"Kleiig zand, zandige klei en leem ",0.252419401614129,9.4837952411877e-05
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),5,Fijn zand ,3.052346743,1.59382820196623
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),6,Midden zand ,4.70110165253667,1.59382820196623
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),7,"Grof zand, grind en schelpen ",21.2348565956226,15.0834039746289
+ECge,6400,Formatie van Echteld (geulafzettingen generatie E),8,Grind (indien apart gemodelleerd) ,85.1,85.1
+EE,4110,Eem Formatie,1,Organisch materiaal (veen) ,0.049,0.049
+EE,4110,Eem Formatie,2,Klei ,0.487221707794069,0.000705791252902199
+EE,4110,Eem Formatie,3,"Kleiig zand, zandige klei en leem ",0.487221707794069,0.000705791252902199
+EE,4110,Eem Formatie,5,Fijn zand ,1.26050710263219,0.50184191408328
+EE,4110,Eem Formatie,6,Midden zand ,2.95774195547431,0.111417606661094
+EE,4110,Eem Formatie,7,"Grof zand, grind en schelpen ",11.627343378729,2.96069522597118
+EE,4110,Eem Formatie,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+GE,5020,Door landijs gestuwde afzettingen,1,Organisch materiaal (veen) ,0.049,0.049
+GE,5020,Door landijs gestuwde afzettingen,2,Klei ,0.0046,0.0046
+GE,5020,Door landijs gestuwde afzettingen,3,"Kleiig zand, zandige klei en leem ",0.04,0.04
+GE,5020,Door landijs gestuwde afzettingen,5,Fijn zand ,0.95776731060603,0.585878332996511
+GE,5020,Door landijs gestuwde afzettingen,6,Midden zand ,4.93970442359087,2.05507307826362
+GE,5020,Door landijs gestuwde afzettingen,7,"Grof zand, grind en schelpen ",15.3649972719478,12.4371907751905
+GE,5020,Door landijs gestuwde afzettingen,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+IE,5160,Formatie van Inden,1,Organisch materiaal (veen) ,0.0002,0.0002
+IE,5160,Formatie van Inden,2,Klei ,0.0002,0.0002
+IE,5160,Formatie van Inden,3,"Kleiig zand, zandige klei en leem ",0.004,0.004
+IE,5160,Formatie van Inden,5,Fijn zand ,3.208843907,3.300409096
+IE,5160,Formatie van Inden,6,Midden zand ,10.10057386,8.819849757
+IE,5160,Formatie van Inden,7,"Grof zand, grind en schelpen ",45.0,22.5
+IE,5160,Formatie van Inden,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+KI,5140,Kiezeloöliet Formatie,1,Organisch materiaal (veen) ,0.0105550023884953,0.00281494679820956
+KI,5140,Kiezeloöliet Formatie,2,Klei ,0.234309831295264,0.000137912894666946
+KI,5140,Kiezeloöliet Formatie,3,"Kleiig zand, zandige klei en leem ",0.234309831295264,0.000137912894666946
+KI,5140,Kiezeloöliet Formatie,5,Fijn zand ,1.38850996078748,0.971685396884222
+KI,5140,Kiezeloöliet Formatie,6,Midden zand ,3.58090507313897,1.46242824947368
+KI,5140,Kiezeloöliet Formatie,7,"Grof zand, grind en schelpen ",17.2579481931186,12.5015884743906
+KI,5140,Kiezeloöliet Formatie,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",1,Organisch materiaal (veen) ,0.049,0.049
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",2,Klei ,0.843439303902334,0.000535604865666857
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",3,"Kleiig zand, zandige klei en leem ",0.843439303902334,0.000535604865666857
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",5,Fijn zand ,1.08658915023622,0.639171468163399
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",6,Midden zand ,5.57690986116341,3.99595213426517
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",7,"Grof zand, grind en schelpen ",20.4783697446951,16.4548205474294
+KR1,4010,"Formatie van Kreftenheye en Formatie van Boxtel, Laagpakket van Delwijnen",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",1,Organisch materiaal (veen) ,0.049,0.049
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",2,Klei ,0.0100820629495191,3.16125122432287e-05
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",3,"Kleiig zand, zandige klei en leem ",0.02,0.02
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",5,Fijn zand ,2.188543727,1.726913572
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",6,Midden zand ,9.224219039,3.713409936
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",7,"Grof zand, grind en schelpen ",58.8,58.8
+KRWY,4000,"Formatie van Kreftenheye, Laag van Wijchen",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+KW,4090,Formatie van Koewacht,1,Organisch materiaal (veen) ,0.004314807,0.004314807
+KW,4090,Formatie van Koewacht,2,Klei ,0.000341602,0.000341602
+KW,4090,Formatie van Koewacht,3,"Kleiig zand, zandige klei en leem ",0.001297475,0.001297475
+KW,4090,Formatie van Koewacht,5,Fijn zand ,5.487118702,3.169758874
+KW,4090,Formatie van Koewacht,6,Midden zand ,6.23606017260504,5.30699759958756
+KW,4090,Formatie van Koewacht,7,"Grof zand, grind en schelpen ",15.4075775161385,14.173632558081
+KW,4090,Formatie van Koewacht,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+MS,5130,Formatie van Maassluis,1,Organisch materiaal (veen) ,0.0004,0.0004
+MS,5130,Formatie van Maassluis,2,Klei ,0.00439471950795145,7.34500096632917e-05
+MS,5130,Formatie van Maassluis,3,"Kleiig zand, zandige klei en leem ",0.00439471950795145,0.0031
+MS,5130,Formatie van Maassluis,5,Fijn zand ,1.811890286,0.787501107444944
+MS,5130,Formatie van Maassluis,6,Midden zand ,2.33256885832654,0.787501107444944
+MS,5130,Formatie van Maassluis,7,"Grof zand, grind en schelpen ",24.2,17.0
+MS,5130,Formatie van Maassluis,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",1,Organisch materiaal (veen) ,0.000313921445642591,6.32570035426544e-05
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",2,Klei ,1.63693755981648,0.0181711648775731
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",5,Fijn zand ,1.12941485466191,0.617086853314213
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",6,Midden zand ,4.43126523501812,2.49345250449753
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NAWA2,1050,"Formatie van Naaldwijk, Laagpakket van Walcheren, gelegen onder Formatie van Naaldwijk, Laagpakket van Zandvoort",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",1,Organisch materiaal (veen) ,0.000313921445642591,6.32570035426544e-05
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",2,Klei ,1.63693755981648,0.0181711648775731
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",5,Fijn zand ,1.12941485466191,0.617086853314213
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",6,Midden zand ,4.43126523501812,2.49345250449753
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NAWAga,6010,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie A)",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",1,Organisch materiaal (veen) ,0.000313921445642591,6.32570035426544e-05
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",2,Klei ,1.63693755981648,0.0181711648775731
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",5,Fijn zand ,1.12941485466191,0.617086853314213
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",6,Midden zand ,4.43126523501812,2.49345250449753
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NAWAgb,6110,"Formatie van Naaldwijk, Laagpakket van Walcheren (geulafzettingen generatie B)",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",1,Organisch materiaal (veen) ,0.000111560216757591,2.34759570222348e-05
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",2,Klei ,1.63693755981648,0.0181711648775731
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",5,Fijn zand ,1.12941485466191,0.617086853314213
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",6,Midden zand ,4.43126523501812,2.49345250449753
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NAWO,1100,"Formatie van Naaldwijk, Laagpakket van Wormer",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NAWO en NAWA,-1,,1,Organisch materiaal (veen) ,0.000313921445642591,6.32570035426544e-05
+NAWO en NAWA,-1,,2,Klei ,1.63693755981648,0.0181711648775731
+NAWO en NAWA,-1,,3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NAWO en NAWA,-1,,5,Fijn zand ,1.12941485466191,0.617086853314213
+NAWO en NAWA,-1,,6,Midden zand ,4.43126523501812,2.49345250449753
+NAWO en NAWA,-1,,7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",1,Organisch materiaal (veen) ,0.000872274537804805,0.000109995255972973
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",2,Klei ,0.00291,0.00291
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",3,"Kleiig zand, zandige klei en leem ",0.0314,0.0314
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",5,Fijn zand ,0.00453795245970884,0.00123609885987156
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",6,Midden zand ,0.00453795245970884,0.00123609885987156
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",7,"Grof zand, grind en schelpen ",12.965,12.692
+NIBA,1130,"Formatie van Nieuwkoop, Basisveen Laag",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",1,Organisch materiaal (veen) ,0.000978951986824535,0.000247176349307907
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",2,Klei ,12.965,12.692
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",3,"Kleiig zand, zandige klei en leem ",0.04,0.04
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",5,Fijn zand ,1.21454638,0.788548671
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",6,Midden zand ,4.599597206,4.570085791
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",7,"Grof zand, grind en schelpen ",12.965,12.692
+NIGR,1010,"Formatie van Nieuwkoop, Laagpakket van Griendtsveen",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",1,Organisch materiaal (veen) ,0.00177791246161756,0.000423475579059717
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",2,Klei ,0.00349,0.00349
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",3,"Kleiig zand, zandige klei en leem ",0.0525,0.0525
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",5,Fijn zand ,1.21454638,0.788548671
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",6,Midden zand ,4.599597206,4.570085791
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",7,"Grof zand, grind en schelpen ",12.965,12.692
+NIHO,1090,"Formatie van Nieuwkoop, Hollandveen Laagpakket",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",1,Organisch materiaal (veen) ,0.000111560216757591,2.34759570222348e-05
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",2,Klei ,1.63693755981648,0.0181711648775731
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",5,Fijn zand ,1.12941485466191,0.617086853314213
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",6,Midden zand ,4.43126523501812,2.49345250449753
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+NWNZ,1110,"Formatie van Naaldwijk, laagpakketten van Wormer en Zandvoort",8,Grind (indien apart gemodelleerd) ,85.1,85.1
+OO,5150,Formatie van Oosterhout,1,Organisch materiaal (veen) ,0.0004,0.0004
+OO,5150,Formatie van Oosterhout,2,Klei ,0.0022,0.0022
+OO,5150,Formatie van Oosterhout,3,"Kleiig zand, zandige klei en leem ",0.0057,0.0057
+OO,5150,Formatie van Oosterhout,5,Fijn zand ,1.639466128,0.788548671
+OO,5150,Formatie van Oosterhout,6,Midden zand ,3.58158293472301,3.29995892667953
+OO,5150,Formatie van Oosterhout,7,"Grof zand, grind en schelpen ",24.2,17.0
+OO,5150,Formatie van Oosterhout,9,Schelpen (indien apart gemodelleerd) ,28.71213973,28.71213973
+PZWA,5120,Formatie van Peize en Formatie van Waalre,1,Organisch materiaal (veen) ,0.00780388242132147,0.000730900641862207
+PZWA,5120,Formatie van Peize en Formatie van Waalre,2,Klei ,0.232749807668561,0.000190023853726446
+PZWA,5120,Formatie van Peize en Formatie van Waalre,3,"Kleiig zand, zandige klei en leem ",0.232749807668561,0.000190023853726446
+PZWA,5120,Formatie van Peize en Formatie van Waalre,5,Fijn zand ,0.828018956092691,0.547132934946566
+PZWA,5120,Formatie van Peize en Formatie van Waalre,6,Midden zand ,3.6444181644955,2.30087480346126
+PZWA,5120,Formatie van Peize en Formatie van Waalre,7,"Grof zand, grind en schelpen ",20.6671037276776,14.1334513799448
+PZWA,5120,Formatie van Peize en Formatie van Waalre,8,Grind (indien apart gemodelleerd) ,125.0,125.0
+ST,5070,Formatie van Sterksel,1,Organisch materiaal (veen) ,0.049,0.049
+ST,5070,Formatie van Sterksel,2,Klei ,1.25084333021367,0.000954664166489149
+ST,5070,Formatie van Sterksel,3,"Kleiig zand, zandige klei en leem ",1.25084333021367,0.000954664166489149
+ST,5070,Formatie van Sterksel,5,Fijn zand ,3.052346743,2.59356194977781
+ST,5070,Formatie van Sterksel,6,Midden zand ,4.31733764192514,2.59356194977781
+ST,5070,Formatie van Sterksel,7,"Grof zand, grind en schelpen ",20.1202208250078,15.7797847248935
+ST,5070,Formatie van Sterksel,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+SY,5090,Formatie van Stramproy,1,Organisch materiaal (veen) ,0.049,0.049
+SY,5090,Formatie van Stramproy,2,Klei ,0.0715513108765599,4.36952536398173e-05
+SY,5090,Formatie van Stramproy,3,"Kleiig zand, zandige klei en leem ",0.0715513108765599,4.36952536398173e-05
+SY,5090,Formatie van Stramproy,5,Fijn zand ,0.892279176179738,0.210018995244024
+SY,5090,Formatie van Stramproy,6,Midden zand ,2.93646706077295,0.87702431206029
+SY,5090,Formatie van Stramproy,7,"Grof zand, grind en schelpen ",7.1075858268199,4.8872136781634
+SY,5090,Formatie van Stramproy,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+UR2,5060,Formatie van Urk,1,Organisch materiaal (veen) ,0.049,0.049
+UR2,5060,Formatie van Urk,2,Klei ,0.0046,0.0046
+UR2,5060,Formatie van Urk,3,"Kleiig zand, zandige klei en leem ",0.04,0.04
+UR2,5060,Formatie van Urk,5,Fijn zand ,0.95776731060603,0.585878332996511
+UR2,5060,Formatie van Urk,6,Midden zand ,4.93970442359087,2.05507307826362
+UR2,5060,Formatie van Urk,7,"Grof zand, grind en schelpen ",15.3649972719478,12.4371907751905
+UR2,5060,Formatie van Urk,8,Grind (indien apart gemodelleerd) ,85.1,85.1
+WA,5110,Formatie van Waalre,1,Organisch materiaal (veen) ,0.00780388242132147,0.000730900641862207
+WA,5110,Formatie van Waalre,2,Klei ,0.232749807668561,0.000190023853726446
+WA,5110,Formatie van Waalre,3,"Kleiig zand, zandige klei en leem ",0.232749807668561,0.000190023853726446
+WA,5110,Formatie van Waalre,5,Fijn zand ,0.828018956092691,0.547132934946566
+WA,5110,Formatie van Waalre,6,Midden zand ,3.6444181644955,2.30087480346126
+WA,5110,Formatie van Waalre,7,"Grof zand, grind en schelpen ",20.6671037276776,14.1334513799448
+WA,5110,Formatie van Waalre,8,Grind (indien apart gemodelleerd) ,125.0,125.0
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,1,Organisch materiaal (veen) ,0.05,0.05
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,2,Klei ,0.005,0.005
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,3,"Kleiig zand, zandige klei en leem ",0.02,0.02
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,5,Fijn zand ,2.5,2.0
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,6,Midden zand ,5.0,5.0
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,7,"Grof zand, grind en schelpen ",25.0,20.0
+USER INPUT,999,Default waarde als stratigrafische eenheid niet voorkomt in tabel,8,Grind (indien apart gemodelleerd) ,85.0,85.0
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",1,Organisch materiaal (veen) ,0.000357318273246172,5.21233653595171e-05
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",3,"Kleiig zand, zandige klei en leem ",1.83482963361234,0.0192462785505905
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",5,Fijn zand ,1.1294556370301,0.617086849079981
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",6,Midden zand ,4.31160800362966,2.593007558907
+USER INPUT,1020,"Formatie van Naaldwijk, Laagpakket van Schoorl",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",1,Organisch materiaal (veen) ,0.000357318273246172,5.21233653595171e-05
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",3,"Kleiig zand, zandige klei en leem ",1.83482963361234,0.0192462785505905
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",5,Fijn zand ,1.1294556370301,0.617086849079981
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",6,Midden zand ,4.31160800362966,2.593007558907
+USER INPUT,1030,"Formatie van Naaldwijk, Laagpakket van Walcheren (gedeelte boven NAZA)",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",1,Organisch materiaal (veen) ,0.000357318273246172,5.21233653595171e-05
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",3,"Kleiig zand, zandige klei en leem ",1.83482963361234,0.0192462785505905
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",5,Fijn zand ,1.1294556370301,0.617086849079981
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",6,Midden zand ,4.31160800362966,2.593007558907
+USER INPUT,1040,"Formatie van Naaldwijk, Laagpakket van Zandvoort",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",1,Organisch materiaal (veen) ,0.000978958601296406,0.000247176350998929
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",3,"Kleiig zand, zandige klei en leem ",0.04,0.04
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",5,Fijn zand ,1.21454638,0.788548671
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",6,Midden zand ,4.599597206,4.570085791
+USER INPUT,1045,"Formatie van Nieuwkoop, Laag van Nij Beets",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",1,Organisch materiaal (veen) ,5.03053348549571e-05,1.9303508919502e-05
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",3,"Kleiig zand, zandige klei en leem ",1.83482963361234,0.0192462785505905
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",5,Fijn zand ,1.1294556370301,0.617086849079981
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",6,Midden zand ,4.31160800362966,2.593007558907
+USER INPUT,1080,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Bergen",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",1,Organisch materiaal (veen) ,5.03053348549571e-05,1.9303508919502e-05
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",2,Klei ,1.83482963361234,0.0192462785505905
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",3,"Kleiig zand, zandige klei en leem ",1.83482963361234,0.0192462785505905
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",5,Fijn zand ,1.1294556370301,0.617086849079981
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",6,Midden zand ,4.31160800362966,2.593007558907
+USER INPUT,1120,"Formatie van Naaldwijk, Laagpakket van Wormer, Laag van Velsen",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,1130,"Formatie van Nieuwkoop, Basisveen Laag",7,"Grof zand, grind en schelpen ",14.1905709933868,13.2256282705314
+USER INPUT,2000,Formatie van Naaldwijk,1,Organisch materiaal (veen) ,0.000313921445642591,6.32570035426544e-05
+USER INPUT,2000,Formatie van Naaldwijk,2,Klei ,1.63693755981648,0.0181711648775731
+USER INPUT,2000,Formatie van Naaldwijk,3,"Kleiig zand, zandige klei en leem ",1.63693755981648,0.0181711648775731
+USER INPUT,2000,Formatie van Naaldwijk,5,Fijn zand ,1.12941485466191,0.617086853314213
+USER INPUT,2000,Formatie van Naaldwijk,6,Midden zand ,4.43126523501812,2.49345250449753
+USER INPUT,2000,Formatie van Naaldwijk,7,"Grof zand, grind en schelpen ",14.8135208116406,13.7993741198054
+USER INPUT,2000,Formatie van Naaldwijk,8,Grind (indien apart gemodelleerd) ,85.1,85.1

--- a/nlmod/data/geotop/litho_eenheden.csv
+++ b/nlmod/data/geotop/litho_eenheden.csv
@@ -1,11 +1,11 @@
-litho_code,lithologie,hor_conductance_default,color
-0,antropogeen,5,Gray
-1,veen,0.001,DarkRed
-2,klei,0.01,Green
-3,kleiig zand,0.1,DarkOliveGreen
-4,onbekend,1,None
-5,fijn zand,5,Yellow
-6,midden zand,10,GoldenRod
-7,grof zand,50,DarkGoldenRod
-8,grind,100,Orange
-9,schelpen,100,Blue
+lithok,lithologie,afkorting,kh,color
+0,antropogeen,a,5,Gray
+1,organisch materiaal (veen),v,0.001,DarkRed
+2,klei,k,0.01,Green
+3,"klei zandig, zandige klei en leem",kz,0.1,DarkOliveGreen
+4,onbekend,o,1.,None
+5,zand fijn,zf,5.,Yellow
+6,zand midden,zm,10.,GoldenRod
+7,zand grof,zg,50.,DarkGoldenRod
+8,grind,g,100.,Orange
+9,schelpen,she,100.,Blue

--- a/nlmod/data/geotop/litho_eenheden.csv
+++ b/nlmod/data/geotop/litho_eenheden.csv
@@ -1,11 +1,11 @@
-lithok,lithologie,afkorting,kh,color
-0,antropogeen,a,5,Gray
-1,organisch materiaal (veen),v,0.001,DarkRed
-2,klei,k,0.01,Green
-3,"klei zandig, zandige klei en leem",kz,0.1,DarkOliveGreen
-4,onbekend,o,1.,None
-5,zand fijn,zf,5.,Yellow
-6,zand midden,zm,10.,GoldenRod
-7,zand grof,zg,50.,DarkGoldenRod
-8,grind,g,100.,Orange
-9,schelpen,she,100.,Blue
+lithok,code,name,kh,color
+0,a,antropogeen,5,Gray
+1,v,organisch materiaal (veen),0.001,DarkRed
+2,k,klei,0.01,Green
+3,kz,"klei zandig, zandige klei en leem",0.1,DarkOliveGreen
+4,o,onbekend,1.,None
+5,zf,zand fijn,5.,Yellow
+6,zm,zand midden,10.,GoldenRod
+7,zg,zand grof,50.,DarkGoldenRod
+8,g,grind,100.,Orange
+9,she,schelpen,100.,Blue

--- a/nlmod/dims/layers.py
+++ b/nlmod/dims/layers.py
@@ -116,10 +116,8 @@ def layer_split_top_bot(ds, split_dict, layer="layer", top="top", bot="botm"):
 
     # loop over original layers
     for i in range(ds[layer].size):
-
         # check if layer should be split
         if i in split_dict:
-
             # set new top based on old top
             if top3d:
                 new_top.data[j] = ds[top].data[i]
@@ -356,7 +354,6 @@ def layer_combine_top_bot(ds, combine_layers, layer="layer", top="top", bot="bot
 
     # loop over original layers
     for i in range(ds.layer.size):
-
         # check whether to combine layers
         if i in np.concatenate(combine_layers):
             # get indices of layers
@@ -951,7 +948,6 @@ def fill_top_and_bottom(ds):
         else:
             # by setting the botm to the botm of the layer above
             botm[lay, mask] = botm[lay - 1, mask]
-    ds["top"].data = top
     return ds
 
 

--- a/nlmod/read/geotop.py
+++ b/nlmod/read/geotop.py
@@ -386,10 +386,15 @@ def add_kh_and_kv(
                 continue
             probality = gt[f"kans_{ilithok}"].data
             if "strat" in df:
-                khi = np.full(strat.shape, np.NaN)
-                kvi = np.full(strat.shape, np.NaN)
+                khi, kvi = _handle_nans_in_stochastic_approach(
+                    np.NaN, np.NaN, kh_method, kv_method
+                )
+                khi = np.full(strat.shape, khi)
+                kvi = np.full(strat.shape, kvi)
                 for istrat in strat_un:
                     mask = (strat == istrat) & (probality > 0)
+                    if not mask.any():
+                        continue
                     kh_sel, kv_sel = _get_kh_kv_from_df(
                         df, ilithok, istrat, anisotropy=anisotropy, mask=mask
                     )

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -72,9 +72,7 @@ def get_combined_layer_models(
         geotop_ds = geotop.get_geotop(extent, regis_ds)
 
     if use_regis and use_geotop:
-        regis_geotop_ds = add_geotop_to_regis_hlc(regis_ds, geotop_ds)
-
-        combined_ds = regis_geotop_ds
+        combined_ds = add_geotop_to_regis_hlc(regis_ds, geotop_ds)
     elif use_regis:
         combined_ds = regis_ds
     else:

--- a/nlmod/read/regis.py
+++ b/nlmod/read/regis.py
@@ -77,7 +77,7 @@ def get_combined_layer_models(
         raise ValueError("layer models without REGIS not supported")
 
     if use_geotop:
-        geotop_ds = geotop.geotop.get_geotop_raw_within_extent(extent)
+        geotop_ds = geotop.get_geotop_raw_within_extent(extent)
 
     if use_regis and use_geotop:
         combined_ds = add_geotop_to_regis_layers(

--- a/tests/test_002_regis_geotop.py
+++ b/tests/test_002_regis_geotop.py
@@ -53,5 +53,5 @@ def test_get_regis_geotop_keep_all_layers(
     regis_geotop_ds = regis.get_combined_layer_models(
         extent, use_regis=True, use_geotop=True, remove_nan_layers=False
     )
-    assert regis_geotop_ds.dims["layer"] == 135
+    assert regis_geotop_ds.dims["layer"] == 137
     return regis_geotop_ds

--- a/tests/test_002_regis_geotop.py
+++ b/tests/test_002_regis_geotop.py
@@ -24,7 +24,6 @@ def test_get_regis_botm_layer_BEk1(
     extent=[98700.0, 99000.0, 489500.0, 489700.0],
     botm_layer="MSc",
 ):
-    # extent, nrow, ncol = regis.fit_extent_to_regis(extent, delr, delc)
     regis_ds = regis.get_regis(extent, botm_layer)
     assert regis_ds.dims["layer"] == 15
     assert regis_ds.layer.values[-1] == botm_layer
@@ -33,8 +32,7 @@ def test_get_regis_botm_layer_BEk1(
 
 # @pytest.mark.skip(reason="too slow")
 def test_get_geotop(extent=[98600.0, 99000.0, 489400.0, 489700.0]):
-    regis_ds = test_get_regis(extent=extent)
-    geotop_ds = geotop.get_geotop(extent, regis_ds)
+    geotop_ds = geotop.get_geotop(extent)
     return geotop_ds
 
 
@@ -50,7 +48,7 @@ def test_get_regis_geotop(extent=[98600.0, 99000.0, 489400.0, 489700.0]):
 
 # @pytest.mark.skip(reason="too slow")
 def test_get_regis_geotop_keep_all_layers(
-    extent=[98600.0, 99000.0, 489400.0, 489700.0], delr=100.0, delc=100.0
+    extent=[98600.0, 99000.0, 489400.0, 489700.0],
 ):
     regis_geotop_ds = regis.get_combined_layer_models(
         extent, use_regis=True, use_geotop=True, remove_nan_layers=False


### PR DESCRIPTION
This pull request improves the way GeoTOP is used to generate geohydrological properties for groundwater models. Some improvements are:
- geohydrological properties (kh and kv) can now be calculated from a combination of lithok and strat as well.
- geohydrological properties (kh and kv) can now also be calculated from the probabilities of each lithoclass.
- GeoTOP data can be aggregated to any layer model in a model Dataset using nlmod.read.aggregate_to_ds()
- GeoTOP data can now be used to replace any layer of REGIS in get_combined_layer
- the GeoTOP code has been simplified
-  a notebook is added to demonstrate the first three points on this list