### PR TITLE
Deprecate nlmod facet plot method

### DIFF
--- a/docs/examples/00_model_from_scratch.ipynb
+++ b/docs/examples/00_model_from_scratch.ipynb
@@ -277,8 +277,8 @@
     "    ds=ds,\n",
     "    cmap=\"RdYlBu\",\n",
     "    ax=ax,\n",
-    "    edgecolor=\"k\",\n",
     ")\n",
+    "nlmod.plot.modelgrid(ds, ax=ax, alpha=0.5, lw=0.5)\n",
     "ax.axis(extent)\n",
     "cbar = ax.figure.colorbar(pc, shrink=1.0)\n",
     "cbar.set_label(\"head [m NAP]\")\n",
@@ -300,17 +300,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = nlmod.plot.facet_plot(\n",
-    "    gwf,\n",
-    "    head,\n",
-    "    lbl=\"head [m NAP]\",\n",
-    "    plot_dim=\"layer\",\n",
-    "    period=0,\n",
+    "fg = head.plot(\n",
+    "    x=\"x\",\n",
+    "    y=\"y\",\n",
+    "    col=\"layer\",\n",
+    "    col_wrap=3,\n",
     "    cmap=\"RdYlBu\",\n",
-    "    plot_bc={\"WEL\": {}},\n",
-    "    plot_grid=True,\n",
-    ")"
+    "    subplot_kws={\"aspect\": \"equal\"},\n",
+    ")\n",
+    "\n",
+    "for iax in fg.axs.flat:\n",
+    "    nlmod.plot.modelgrid(ds, ax=iax, alpha=0.5, lw=0.5)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/run_all_notebooks.py
+++ b/docs/examples/run_all_notebooks.py
@@ -1,3 +1,4 @@
+# %%
 from glob import glob
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
@@ -44,3 +45,5 @@ for notebook in notebook_list:
     os.system(
         f"jupyter nbconvert --clear-output --inplace --ClearMetadataPreprocessor.enabled=True {notebook}"
     )
+
+# %%

--- a/nlmod/plot/flopy.py
+++ b/nlmod/plot/flopy.py
@@ -235,7 +235,6 @@ def facet_plot(
     xlim=None,
     ylim=None,
     grid=False,
-    figdir=None,
     figsize=(10, 8),
     plot_bc=None,
     plot_grid=False,
@@ -316,12 +315,5 @@ def facet_plot(
 
     cb = fig.colorbar(qm, ax=axes, shrink=1.0)
     cb.set_label(lbl)
-
-    if figdir:
-        fig.savefig(
-            os.path.join(figdir, f"{lbl}_per_{plot_dim}.png"),
-            dpi=150,
-            bbox_inches="tight",
-        )
 
     return fig, axes


### PR DESCRIPTION
Function is outdated, and should either be updated or removed. 

The `nlmod.plot.flopy` version is more up to date, creating a separate issue to figure out what to do with that later.

