### PR TITLE
Incomplete knmi ts breaks get_recharge function

### DIFF
--- a/nlmod/read/knmi.py
+++ b/nlmod/read/knmi.py
@@ -277,11 +277,11 @@ def get_knmi_at_locations(ds, start="2010", end=None, most_common_station=False)
 
     # get knmi data stations closest to any grid cell
     oc_knmi_prec = hpd.ObsCollection.from_knmi(
-        stns=stns_rd, starts=[start], ends=[end], meteo_vars=["RD"]
+        stns=stns_rd, starts=[start], ends=[end], meteo_vars=["RD"], fill_missing_obs=True
     )
 
     oc_knmi_evap = hpd.ObsCollection.from_knmi(
-        stns=stns_ev24, starts=[start], ends=[end], meteo_vars=["EV24"]
+        stns=stns_ev24, starts=[start], ends=[end], meteo_vars=["EV24"], fill_missing_obs=True
     )
 
     return locations, oc_knmi_prec, oc_knmi_evap

--- a/nlmod/version.py
+++ b/nlmod/version.py
@@ -1,7 +1,7 @@
 from importlib import metadata
 from platform import python_version
 
-__version__ = "0.6.2b"
+__version__ = "0.7.0"
 
 
 def show_versions() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "affine>=0.3.1",
     "geopandas",
     "owslib>=0.24.1",
-    "hydropandas>=0.7.1",
+    "hydropandas>=0.9.2",
     "shapely>=2.0.0",
     "pyshp>=2.1.3",
     "matplotlib",


### PR DESCRIPTION
Solution provided by Davíd.

Missing values are filled with nearby time series by setting fill_missing_obs to True